### PR TITLE
Remove hardcoded version of touchstonejs-tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "gulp": "^3.8.10",
     "reactify": "^0.17.1",
-    "touchstonejs-tasks": "^0.0.3"
+    "touchstonejs-tasks": "^0.1.0"
   },
   "scripts": {
     "watch": "gulp watch"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "gulp": "^3.8.10",
     "reactify": "^0.17.1",
-    "touchstonejs-tasks": "0.0.3"
+    "touchstonejs-tasks": "^0.0.3"
   },
   "scripts": {
     "watch": "gulp watch"


### PR DESCRIPTION
v0.0.4 of the touchstonejs-tasks module does not work with Node v0.12.  A PR to fix this has been sent.  Updating the package.json to get the latest updates to the tasks module.